### PR TITLE
using true source-sans stack

### DIFF
--- a/resources/assets/scss/base/_fonts.scss
+++ b/resources/assets/scss/base/_fonts.scss
@@ -1,4 +1,4 @@
-$sans: 'Source Sans Pro', serif;
+$sans: 'source-sans-pro', 'Helvetica', sans-serif;
 
 %sans--medium {
   font-family: $sans;


### PR DESCRIPTION
Using Typekit naming convention for Source Sans.

* blocker... need to verify font is being served