### PR TITLE
Corrects webpack mix config and enforces the use of the mix helper function

### DIFF
--- a/resources/views/legacy/_layouts/logged_in.blade.php
+++ b/resources/views/legacy/_layouts/logged_in.blade.php
@@ -1,11 +1,7 @@
 @extends('legacy._layouts.main')
 
 @push('stylesheets')
-    @if(App::environment() == "local")
-        <link rel="stylesheet" href="{{ URL::asset('legacy/css/app_logged_in.css') }}">
-    @else
-        <link rel="stylesheet" href="{{ mix('legacy/css/app_logged_in.css') }}">
-    @endif
+    <link rel="stylesheet" href="{{ mix('legacy/css/app_logged_in.css') }}">
 @endpush
 
 @section('main_content')

--- a/resources/views/legacy/_layouts/main.blade.php
+++ b/resources/views/legacy/_layouts/main.blade.php
@@ -23,10 +23,10 @@
     @stack('stylesheets')
 
     {{-- TYPEKIT async load --}}
-    <script type="text/javascript" src="{{ URL::asset('/js/vendors/typekit.js') }}"></script>
-    
-    @if (App::environment('production'))
-        @script(js/vendors/intercom.js)
+    <script type="text/javascript" src="{{ mix('/js/vendors/typekit.js') }}"></script>
+
+    @if (App::environment(['production', 'staging']))
+        <script type="text/javascript" src="{{ mix('js/vendors/intercom.js') }}"></script>
     @endif
 
 </head>
@@ -55,20 +55,10 @@
 
     @if (Auth::guest())
         @script(/js/vendors/modernizr-custom.js)
-        @if(App::environment() == "local")
-            <script type="text/javascript" src="{{ URL::asset('/legacy/js/app_public.js') }}"></script>
-        @else
-            <script type="text/javascript" src="{{ mix('/legacy/js/app_public.js') }}"></script>
-        @endif
-
+        <script type="text/javascript" src="{{ mix('/legacy/js/app_public.js') }}"></script>
     @else
         @script(https://js.stripe.com/v2/)
-        @if(App::environment() == "local")
-            <script type="text/javascript" src="{{ URL::asset('/legacy/js/app_logged_in.js') }}"></script>
-        @else
-            <script type="text/javascript" src="{{ mix('/legacy/js/app_logged_in.jss') }}"></script>
-        @endif
-
+        <script type="text/javascript" src="{{ mix('/legacy/js/app_logged_in.jss') }}"></script>
     @endif
 
     @stack('scripts')

--- a/resources/views/legacy/_layouts/public.blade.php
+++ b/resources/views/legacy/_layouts/public.blade.php
@@ -1,11 +1,7 @@
 @extends('legacy._layouts.main')
 
 @push('stylesheets')
-    @if(App::environment() == "local")
-        <link rel="stylesheet" href="{{ URL::asset('legacy/css/app_public.css') }}">
-    @else
-        <link rel="stylesheet" href="{{ mix('legacy/css/app_public.css') }}">
-    @endif
+    <link rel="stylesheet" href="{{ mix('legacy/css/app_public.css') }}">
 @endpush
 
 @section('main_content')

--- a/resources/views/legacy/legal/legal.blade.php
+++ b/resources/views/legacy/legal/legal.blade.php
@@ -2,7 +2,7 @@
 @section('page_title',$page_title)
 
 @push('stylesheets')
-    <link rel="stylesheet" href="{{ URL::asset('legacy/css/legal.css') }}">
+    <link rel="stylesheet" href="{{ mix('legacy/css/legal.css') }}">
 @endpush
 
 @section('content')

--- a/resources/views/pages/dashboard/index.blade.php
+++ b/resources/views/pages/dashboard/index.blade.php
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="{{ mix('css/application.css') }}">
 
         <!-- Typekit -->
-        <script type="text/javascript" src="{{ URL::asset('js/vendors/typekit.js') }}"></script>
+        <script type="text/javascript" src="{{ mix('js/vendors/typekit.js') }}"></script>
 
     </head>
     <body>
@@ -72,11 +72,7 @@
       </script>
 
       @script(https://js.stripe.com/v2/)
-      @if(App::environment() == "local")
-          <script type="text/javascript" src="{{ URL::asset('js/dashboard/main.js') }}"></script>
-      @else
-          <script type="text/javascript" src="{{ mix('js/dashboard/main.js') }}"></script>
-      @endif
+      <script type="text/javascript" src="{{ mix('js/dashboard/main.js') }}"></script>
 
       @stack('scripts')
 

--- a/resources/views/pages/schedule.blade.php
+++ b/resources/views/pages/schedule.blade.php
@@ -16,11 +16,11 @@
         <link rel="stylesheet" href="{{ mix('css/application.css') }}">
 
         <!-- Typekit -->
-        <script type="text/javascript" src="{{ URL::asset('js/vendors/typekit.js') }}"></script>
+        <script type="text/javascript" src="{{ mix('js/vendors/typekit.js') }}"></script>
 
         {{-- Tracking scripts (GA, Pixel, mixpanel) load with vue-multianalytics --}}
         @if (App::environment('local'))
-          <script type="text/javascript" src="{{ URL::asset('js/vendors/intercom.js') }}"></script>
+          <script type="text/javascript" src="{{ mix('js/vendors/intercom.js') }}"></script>
         @endif
 
     </head>
@@ -55,12 +55,6 @@
       <script>
         window.Laravel = {!! $vue_data !!}
       </script>
-      @if(App::environment() == "local")
-        <script type="text/javascript" src="{{ URL::asset('js/schedule/main.js') }}"></script>
-      @else
-        <script type="text/javascript" src="{{ mix('js/schedule/main.js') }}"></script>
-      @endif
-
-
+      <script type="text/javascript" src="{{ mix('js/schedule/main.js') }}"></script>
     </body>
 </html>

--- a/resources/views/pages/signup.blade.php
+++ b/resources/views/pages/signup.blade.php
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="{{ mix('css/application.css') }}">
 
         <!-- Typekit -->
-        <script type="text/javascript" src="{{ URL::asset('js/vendors/typekit.js') }}"></script>
+        <script type="text/javascript" src="{{ mix('js/vendors/typekit.js') }}"></script>
 
     </head>
     <body>
@@ -50,11 +50,6 @@
       <script>
         window.Laravel = {!! $vue_data !!}
       </script>
-      @if(App::environment() == "local")
-          <script type="text/javascript" src="{{ URL::asset('js/signup/main.js') }}"></script>
-      @else
-          <script type="text/javascript" src="{{ mix('js/signup/main.js') }}"></script>
-      @endif
-
+      <script type="text/javascript" src="{{ mix('js/signup/main.js') }}"></script>
     </body>
 </html>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,16 +17,12 @@ mix.options({processCssUrls: false})
    .js('resources/assets/js/pages/schedule/main.js', 'public/js/schedule')
    .js('resources/assets/legacy/js/app_public.js', 'public/legacy/js')
    .js('resources/assets/legacy/js/app_logged_in.js', 'public/legacy/js')
-   .copy([
-        'resources/assets/js/vendors/modernizr-custom.js',
-        'resources/assets/js/vendors/typekit.js',
-        'resources/assets/js/vendors/facebook.js',
-        'resources/assets/js/vendors/googleanalytics.js',
-        'resources/assets/js/vendors/intercom.js',
-        'resources/assets/js/vendors/mixpanel.js'
-    ], 'public/js/vendors')
+   .js('resources/assets/js/vendors/modernizr-custom.js', 'public/js/vendors')
+   .js('resources/assets/js/vendors/intercom.js', 'public/js/vendors')
+   .js('resources/assets/js/vendors/typekit.js', 'public/js/vendors')
    .copy('resources/assets/images', 'public/images', false)
    .sass('resources/assets/scss/application.scss', 'public/css')
+   .sass('resources/assets/legacy/sass/pages/legal.scss', 'public/legacy/css')
    .sass('resources/assets/legacy/sass/app_public.scss', 'public/legacy/css');
 
 if (mix.config.inProduction) {


### PR DESCRIPTION
It looks like something may have changed with how webpack implements the "copy" feature. Either way, I think we had a lot of unnecessary scripts being copied to the public vendor directory since the vue multianalytics package pulls those scripts in on it's own.

My solution here was to use Mix's default `mix.js()` to copy the vendor scripts over to public and call them in the templates using the mix helper function.

This should resolve the issue of intercom not working on production.