### PR TITLE
HAR-213 HOTFIX - Override default fb event string in vue multi-analytics

### DIFF
--- a/resources/assets/js/pages/schedule/Confirmation.vue
+++ b/resources/assets/js/pages/schedule/Confirmation.vue
@@ -48,8 +48,10 @@
       dispatchEvent() {
 
         if (this.env === 'prod') {
-          this.$ma.trackEvent({
+
+            this.$ma.trackEvent({
             action: 'IntakeQ Form Initiated',
+            fb_event: 'ViewContent',
             category: 'clicks',
             properties: { laravel_object: Laravel.user }
           });

--- a/resources/assets/js/pages/schedule/_components/DateTime.vue
+++ b/resources/assets/js/pages/schedule/_components/DateTime.vue
@@ -184,7 +184,15 @@
       this.$eventHub.$on('datetime-change', this.onDateTimeChange);
       this.$eventHub.$emit('animate', this.animClasses, 'anim-fade-slideup-in', true, 300)
       if (this.$parent.env === 'prod') {
-        this.$ma.trackEvent({action: 'View Date and Time Selector', category: 'clicks', properties: {laravel_object: Laravel.user}, value: 'PageView'})
+        this.$ma.trackEvent({
+            action: 'View Date and Time Selector',
+            fb_event: 'ViewContent',
+            category: 'clicks',
+            properties: {
+                laravel_object: Laravel.user
+            },
+            value: 'PageView'
+        })
       }
     },
   }

--- a/resources/assets/js/pages/schedule/_components/Location.vue
+++ b/resources/assets/js/pages/schedule/_components/Location.vue
@@ -39,7 +39,10 @@
     },
     name: 'Location',
     mounted() {
-      this.$ma.trackEvent({value: 'PageView'})
+      this.$ma.trackEvent({
+          value: 'PageView',
+          fb_event: 'ViewContent',
+      })
     }
   }
 </script>

--- a/resources/assets/js/pages/schedule/_components/Modal.vue
+++ b/resources/assets/js/pages/schedule/_components/Modal.vue
@@ -100,7 +100,10 @@
     },
     name: 'Modal',
     mounted() {
-      this.$ma.trackEvent({value: 'PageView'})
+      this.$ma.trackEvent({
+          value: 'PageView',
+          fb_event: 'ViewContent',
+      })
     }
   }
 </script>

--- a/resources/assets/js/pages/schedule/_components/Phone.vue
+++ b/resources/assets/js/pages/schedule/_components/Phone.vue
@@ -92,6 +92,7 @@
       if (this.$parent.env === 'prod') {
         this.$ma.trackEvent({
           action: 'View Personal Contact Form',
+          fb_event: 'ViewContent',
           category: 'clicks',
           properties: { laravel_object: Laravel.user },
           value: 'PageView'

--- a/resources/assets/js/pages/schedule/_components/Practitioner.vue
+++ b/resources/assets/js/pages/schedule/_components/Practitioner.vue
@@ -129,6 +129,7 @@
       if (this.$parent.env === 'prod') {
         this.$ma.trackEvent({
           action: 'View Select Practitioner',
+          fb_event: 'ViewContent',
           category: 'clicks',
           properties: { laravel_object: Laravel.user },
           value: 'PageView',

--- a/resources/assets/js/pages/signup/Interstitial.vue
+++ b/resources/assets/js/pages/signup/Interstitial.vue
@@ -43,7 +43,14 @@
     },
     mounted() {
       if (this.$parent.env === 'prod') {
-        this.$ma.trackEvent({action: 'User Registered/Get Started', category: 'clicks', properties: {laravel_object: Laravel.user}})
+        this.$ma.trackEvent({
+            action: 'User Registered/Get Started',
+            fb_event: 'ViewContent',
+            category: 'clicks',
+            properties: {
+                laravel_object: Laravel.user
+            }
+        })
       }
     }
   }

--- a/resources/assets/js/pages/signup/Signup.vue
+++ b/resources/assets/js/pages/signup/Signup.vue
@@ -108,7 +108,15 @@
     },
     mounted () {
       if (this.env === 'prod') {
-        this.$ma.trackEvent({action: 'View Signup Page', category: 'clicks', properties: {laravel_object: Laravel.user}, value: 'PageView'})
+        this.$ma.trackEvent({
+            action: 'View Signup Page',
+            fb_event: 'ViewContent',
+            category: 'clicks',
+            properties: {
+                laravel_object: Laravel.user
+            },
+            value: 'PageView'
+        })
       }
     }
   }


### PR DESCRIPTION
PR created to fix this on the module's repo.
https://github.com/Glovo/vue-multianalytics/pull/4

Otherwise, we need to manually override the `fb_event` key each time we track an event for `ViewContent`.