### PR TITLE
[HAR-387] Patient appointment update logic

### DIFF
--- a/resources/assets/js/pages/appointments/Appointments.vue
+++ b/resources/assets/js/pages/appointments/Appointments.vue
@@ -268,6 +268,7 @@ export default {
     },
     editableDays() {
       if (this.flyoutMode === 'new') return true;
+      if (this.userType === 'patient' && this.appointment.status !== 'pending') return false;
       return this.checkPastAppointment();
     },
     editableStatus() {
@@ -281,6 +282,7 @@ export default {
     },
     editablePurpose() {
       if (this.flyoutMode === 'new') return true;
+      if (this.userType === 'patient' && this.appointment.status !== 'pending') return false;
       return this.checkPastAppointment();
     },
     emptyTableMsg() {
@@ -299,8 +301,9 @@ export default {
       return this.userType !== 'practitioner';
     },
     visibleUpdateButtons() {
-      return this.flyoutMode === 'update'
-             && ((this.userType === 'patient' && this.checkPastAppointment()) || this.userType !== 'patient');
+      return this.flyoutMode === 'update' &&
+        (this.userType === 'patient' && this.appointment.status === 'pending') &&
+        ((this.userType === 'patient' && this.checkPastAppointment()) || this.userType !== 'patient')
     },
   },
 


### PR DESCRIPTION
Patients can no longer update/cancel appointments if the appointment status is anything other than 'pending'. The appointment data will just appear in the flyout.