### PR TITLE
[HAR-214] Creates leads when zip code is out of serviceable range

### DIFF
--- a/app/Events/OutOfServiceZipCodeRegistered.php
+++ b/app/Events/OutOfServiceZipCodeRegistered.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+
+class OutOfServiceZipCodeRegistered
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+    
+    public $request;
+    public $notes = "Zip code is not serviceable.";
+    
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+    
+}

--- a/app/Http/Controllers/API/V1/UsersController.php
+++ b/app/Http/Controllers/API/V1/UsersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\V1;
 
+use App\Events\OutOfServiceZipCodeRegistered;
 use App\Events\UserRegistered;
 use App\Models\Patient;
 use App\Models\User;
@@ -68,6 +69,9 @@ class UsersController extends BaseAPIController
         ]);
 
         if ($validator->fails()) {
+            if($validator->errors()->get('zip')) {
+                event(new OutOfServiceZipCodeRegistered($request));
+            }
             return $this->respondBadRequest($validator->errors()->first());
         }
 

--- a/app/Listeners/CreateLead.php
+++ b/app/Listeners/CreateLead.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\OutOfServiceZipCodeRegistered;
+use App\Models\Lead;
+
+class CreateLead
+{
+    public function handle(OutOfServiceZipCodeRegistered $event)
+    {
+        try {
+            $lead = new Lead($event->request->only(['first_name', 'last_name', 'email', 'zip']));
+            $lead->notes = $event->notes ?? null;
+            $lead->save();
+        } catch (\Exception $exception) {
+            \Log::error('Unable to create lead with request: ', [$event->request, $exception->getMessage()]);
+        }
+    }
+}

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Lead extends Model
+{
+    protected $guarded = ['created_at'];
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -30,6 +30,9 @@ class EventServiceProvider extends ServiceProvider
             'App\Listeners\SendPractitionerAppointmentUpdatedEmail',
             'App\Listeners\NotifyAppointmentUpdatedSlackChannel',
         ],
+        'App\Events\OutOfServiceZipCodeRegistered' => [
+            'App\Listeners\CreateLead',
+        ],
     ];
 
     protected $subscribe = [

--- a/database/migrations/2017_06_06_204653_create_leads_table.php
+++ b/database/migrations/2017_06_06_204653_create_leads_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateLeadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('leads', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('email')->unique();
+            $table->string('zip')->nullable();
+            $table->string('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('leads');
+    }
+}

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -38,7 +38,7 @@ class RegistrationTest extends TestCase
         $this->assertDatabaseHas('patients', ['user_id' => $created_user_id]);
     }
 
-    public function test_it_does_not_create_a_user_if_the_zip_code_is_not_serviceable()
+    public function test_it_does_not_create_a_user_if_the_zip_code_is_not_serviceable_but_it_does_create_a_lead()
     {
         // Given invalid user data
         $parameters = [
@@ -49,17 +49,20 @@ class RegistrationTest extends TestCase
             'terms' => true,
             'zip' => 11111
         ];
-
+        
         // When a request is made to create a new user
         $response = $this->post(route('users.create'), $parameters);
-
+    
         // It returns a bad request response
         $response->assertStatus(ResponseCode::HTTP_BAD_REQUEST);
-
+        
         // And an appropriate message will be displayed
         $response->assertJsonFragment(["detail" => "Sorry, we do not service this zip."]);
 
         // And no new user is created
         $this->assertDatabaseMissing('users', ['first_name' => 'Albus']);
+        
+        // But a lead is created
+        $this->assertDatabaseHas('leads', ['email' => 'headmaster@hogwarts.co.uk', 'zip' => 11111]);
     }
 }


### PR DESCRIPTION
If a user enters a zip code that is out of our serviceable range, we dispatch an event that will create a lead. 

We can add to this by creating a new listener that will also notify slack, but that wasn't in the scope of this ticket.