### PR TITLE
Appointment Fixes

### DIFF
--- a/resources/assets/js/pages/appointments/Appointments.vue
+++ b/resources/assets/js/pages/appointments/Appointments.vue
@@ -156,7 +156,7 @@
       </table>
       <div class="modal-button-container">
         <button class="button" @click="handleUserAction">Yes, Confirm</button>
-        <button class="button button--cancel" @click="modalActive = false">Go Back</button>
+        <button class="button button--cancel" @click="handleModalClose">Go Back</button>
         <p v-if="userAction !== 'cancel'">You will receive an email confirmation of your updated appointment. We will send you another notification one hour before your appointment.</p>
       </div>
     </Modal>
@@ -457,6 +457,10 @@ export default {
     },
 
     handleModalClose() {
+      if (this.appointment.status === 'canceled') {
+        console.log(this.appointment.status);
+        this.appointment.status = this.appointment.currentStatus;
+      }
       this.modalActive = false;
     },
 


### PR DESCRIPTION
## Tickets
- HAR-432 ⚠️ (could not reproduce)
- HAR-433 👍 
- HAR-434 👍 
- HAR-435 👍 

## Additional
- __Issue:__ If an admin clicks on a canceled appointment and changes it to pending, the update button will be enabled even if that date has since been filled by another appointment. This would lead to a 500 Bad Request returned from the Backend. __Fix:__ If an appointments currentStatus is not pending, when the status changes to pending a check runs to see if that date is still available. If not, a warning message is displayed and the update button remains disabled until a new day and time is selected.

- __Issue:__ If the appointment flyout is open and a user clicks on a different row, the day/time selector will reset accordingly.