### PR TITLE
HAR-536 Signup Funnel Availability Bug

### DIFF
--- a/resources/assets/js/pages/schedule/components/Practitioner.vue
+++ b/resources/assets/js/pages/schedule/components/Practitioner.vue
@@ -134,7 +134,9 @@
         axios.get(`api/v1/practitioners/${this.$root.initialAppointment.practitioner_id}?include=availability`)
           .then(response => {
             this.$parent.practitioner_availability = response.data.meta.availability;
-            this.$parent._availability = transformAvailability(response.data.meta.availability);
+            // The signup funnel will only be completed by patients, so we're passing that in directly to ensure
+            // the 4-hour buffer time slots are eliminated
+            this.$parent._availability = transformAvailability(response.data.meta.availability, 'patient');
 
             // Check if all day objects have empty times arrays
             const hasAvailability = this.$parent._availability.reduce((acc, dayObj) => acc.concat(dayObj.times), []).length;


### PR DESCRIPTION
https://homehero.atlassian.net/browse/HAR-536

## Summary
While not able to replicate the bug described in the ticket, I did find that the signup funnel DateTime component is not taking into account the 4-hour buffer for current days. This was fixed by simply passing in a user type of 'patient' to the transformAvailability method.