### PR TITLE
[HAR-566] Hotfix Patient Dropdown

### DIFF
--- a/resources/assets/js/pages/appointments/Appointments.vue
+++ b/resources/assets/js/pages/appointments/Appointments.vue
@@ -552,6 +552,7 @@ export default {
         this.appointment.patientName = `${data._patientLast}, ${data._patientFirst}`;
         this.appointment.patientPhone = data._patientPhone;
         if (this.userType !== 'patient') this.appointment.patientId = data._patientId;
+        this.patientDisplay = `${this.appointment.patientName} (${this.appointment.patientEmail})`;
 
         // store current date
         this.appointment.currentDate = moment(data._date).format('YYYY-MM-DD HH:mm:ss');
@@ -682,6 +683,7 @@ export default {
       // this.selectedRowData = null;
       // this.selectedRowIndex = null;
       this.noAvailability = false;
+      this.patientDisplay = '';
       return {
         availableTimes: [],
         date: '',


### PR DESCRIPTION
https://homehero.atlassian.net/browse/HAR-566

__Problem__
The current production signup funnel allows users to skip to the dashboard without having filled in their first and last names. Because of this, we have numerous users in the database with null values for names and it's very difficult for Support to do things like change appointment times for them.

__Solution__
This fix temporarily adds the patient's email address to the patient dropdown on the appointments page flyout. This will make it easier for support to identify which client they are managing in the application.