### PR TITLE
[HAR-602] adding 'Account Failed' tracking

### DIFF
--- a/resources/assets/js/pages/get-started/children/Signup.vue
+++ b/resources/assets/js/pages/get-started/children/Signup.vue
@@ -224,6 +224,18 @@ export default {
           // If such a zipcode is entered, the users api will return a 400
           .catch(error => {
             this.responseErrors = error.response.data.errors;
+
+            // track the failed signup
+            if (this.$root.$data.environment === 'production' || this.$root.$data.environment === 'prod') {
+              const email = this.signupData.email;
+              const zip = this.signupData.zip;
+
+              analytics.track("Account Failed", {
+                email: email,
+                zip: zip,
+              });
+            }
+
             this.$router.push({name: 'out-of-range', path: '/out-of-range'});
           });
 


### PR DESCRIPTION
Attaches a Segment event which sends along user `email` and `zip` during a failed, or "out of range" account creation attempt.