### PR TITLE
[HAR-660 Pt. 2] Select first practitioner by default in signup funnel

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -106,7 +106,7 @@ const app = new Vue({
           practitionerState: '',
           selectedDate: null,
           selectedDay: null,
-          selectedPractitioner: null,
+          selectedPractitioner: 0,
           selectedWeek: null,
           selectedTime: null,
           visistedStages: [],


### PR DESCRIPTION
This feature was already merged into 2.4.2 but it needed to select a practitioner by default.