### PR TITLE
[HAR-764] Appointment Time Reset

### DIFF
--- a/resources/assets/js/pages/appointments/Appointments.vue
+++ b/resources/assets/js/pages/appointments/Appointments.vue
@@ -790,9 +790,12 @@ export default {
     },
 
     setAvailableTimes(value, index) {
+      // If the day is changed, reset time and date values
+      this.setTime(null);
       this.appointment.day = value;
       this.appointment.availableTimes = [];
       this.appointment.availableTimes = this.appointment.day
+        // The practitioner index is minus 1 to account for the empty space in the dropdown list
         ? this.appointment.practitionerAvailability[index - 1].data.times
         : [];
     },


### PR DESCRIPTION
__Ticket:__ https://homehero.atlassian.net/browse/HAR-764

# Summary
__Problem:__ If appointment day was changed after it was already set, it disabled the time dropdown but did not actually reset the data, still allowing the user to update the appointment.

__Solution:__ On day change, reset the appointment date and time data which disables the appointment update button