### PR TITLE
[HAR-763] Add support for url parameter tracking

### DIFF
--- a/resources/assets/js/app_public.js
+++ b/resources/assets/js/app_public.js
@@ -273,8 +273,8 @@ const app = new Vue({
           analytics.page(currentPage);
 
           // indentify and send along any url paramaters if they exist
-          if(this.getUrlParams() !== null) {
-            const parameterObject = this.getUrlParams();
+          const parameterObject = this.getUrlParams();
+          if(parameterObject !== null) {
             analytics.identify(parameterObject);
           }
         }


### PR DESCRIPTION
`analytics.identify()` on all public pages sends along url parameters if they exist

`http://goharvey.com/?test=hello&test2=there` sends

```js
analytics.identify(userId, {
  test: 'hello',
  test2: 'there',
});
```

**Notes:**
* adds `getUrlParams()` helper
* reorganizes Page event handling