### PR TITLE
[HAR-762] Bug: Clear Error Message When Reentering Phone

### DIFF
--- a/resources/assets/js/pages/get-started/children/Phone.vue
+++ b/resources/assets/js/pages/get-started/children/Phone.vue
@@ -104,12 +104,19 @@ export default {
     }
   },
   methods: {
+    clearCodeInputs() {
+      Object.keys(this.confirmInputComponent.$refs).forEach(i => {
+        this.confirmInputComponent.$refs[i].value = '';
+      })
+    },
     newPhoneNumber() {
       this.isPhoneProcessing = false;
       this.code = '';
       this.$root.$data.signup.phonePending = false;
       this.$root.$data.signup.codeConfirmed = false;
       this.$root.$data.signup.code = '';
+      this.isInvalidCode = false;
+      this.clearCodeInputs();
     },
     storeCode(value) {
       this.code = value;
@@ -138,9 +145,7 @@ export default {
             this.setInvalidCode();
           }
         }).catch(error => {
-          Object.keys(this.confirmInputComponent.$refs).forEach(i => {
-            this.confirmInputComponent.$refs[i].value = '';
-          })
+          this.clearCodeInputs();
           this.setInvalidCode();
         })
       }
@@ -187,9 +192,7 @@ export default {
       }
     },
     handleNewSend() {
-      Object.keys(this.confirmInputComponent.$refs).forEach(i => {
-        this.confirmInputComponent.$refs[i].value = '';
-      })
+      this.clearCodeInputs();
       this.sendConfirmation();
     },
     sendConfirmation() {


### PR DESCRIPTION
## Summary

Fixes: https://homehero.atlassian.net/browse/HAR-762

On the signup funnel phone step, if a user entered an invalid code they get an error message. If the user clicked back to reenter their phone number, upon returning to the code confirmation step the error would still be there and the previous code was still input. This fix clears both the error message and the old code inputs;