### PR TITLE
[HAR-822] Correctly Styles No CC Error Message

### DIFF
--- a/resources/assets/js/pages/appointments/components/Patient.vue
+++ b/resources/assets/js/pages/appointments/components/Patient.vue
@@ -13,7 +13,8 @@
     <div class="font-sm"><a :href="'mailto:' + email">{{ email }}</a></div>
     <div class="font-sm"><a :href="'tel:' + phone" v-on:click="trackPhoneCall">{{ phone | phone }}</a></div>
     <p v-if="editable && address" v-html="address"></p>
-    <p class="error-text" style="text-align: left;" v-if="shouldShowPaymentError">
+    <p class="copy-error" style="text-align: left;" v-if="shouldShowPaymentError">
+      <br>
       This client has not confirmed payment and cannot be scheduled for an appointment
     </p>
   </div>

--- a/resources/assets/scss/v2/settings/placeholders/_copy.scss
+++ b/resources/assets/scss/v2/settings/placeholders/_copy.scss
@@ -32,8 +32,8 @@
   @extend %copy-main;
   @extend %font-sm;
 
-  color: $color-error;
-  font-weight: $font-normal;
+  color: $color-error !important;
+  font-weight: $font-normal !important;
 }
 
 /// Default anchor tag styling


### PR DESCRIPTION
## Summary

Addresses: https://homehero.atlassian.net/browse/HAR-822

This ticket is reporting accurate functionality. In the video attached, the user selected has a warning message that they do not have a CC on file and so cannot have an appointment created for them. Since they cannot have an appointment created for them, we hide the button altogether.

These changes just update the styling of the message to ensure it's more obvious.