### PR TITLE
[HAR-848] Practitioner List Populated Incorrectly

### DIFF
--- a/resources/assets/js/pages/appointments/Appointments.vue
+++ b/resources/assets/js/pages/appointments/Appointments.vue
@@ -596,13 +596,13 @@ export default {
         if (this.userType !== 'patient') this.appointment.patientId = data._patientId;
         this.patientDisplay = `${this.appointment.patientName} (${this.appointment.patientEmail})`;
 
+        // patient address
+        this.appointment.patientAddress = this.setPatientAddress(data);
+        this.appointment.patientState = data.state;
+
         // If user is admin, filter practitioners by state licensing regulations
         // First reset the practitioner list
         this.setupPractitionerList(this.$root.$data.global.practitioners);
-        this.practitionerList = this.$root.filterPractitioners(this.practitionerList, data.state);
-
-        // patient address
-        this.appointment.patientAddress = this.setPatientAddress(data);
 
         // store current date
         this.appointment.currentDate = moment(data._date).format('YYYY-MM-DD HH:mm:ss');
@@ -789,6 +789,7 @@ export default {
         patientId: '',
         patientName: '',
         patientPhone: '',
+        patientState: '',
         practitionerAvailability: [],
         practitionerId: '',
         practitionerName: '',
@@ -888,6 +889,9 @@ export default {
       });
       if (this.userType === 'practitioner') {
         this.setPractitionerInfo(this.practitionerList[0].data);
+      }
+      if (this.userType === 'admin' && this.appointment.patientState) {
+        this.practitionerList = this.$root.filterPractitioners(this.practitionerList, this.appointment.patientState);
       }
     },
 


### PR DESCRIPTION
## Summary

Fixes: https://homehero.atlassian.net/browse/HAR-848

__Problem__  
The practitioner list was filtered upon row click, but if the practitioner list had not finished loading, the callback would overwrite the filtered list.

__Solution__ 
Practitioner list is now filtered during the setupPractitioner function which fires after practitioner loading has taken place. We also call this function on row click to ensure filtering takes place.