### PR TITLE
Use Google API Key on Geocoder class.

### DIFF
--- a/app/Lib/Clients/Geocoder.php
+++ b/app/Lib/Clients/Geocoder.php
@@ -2,8 +2,7 @@
 
 namespace App\Lib\Clients;
 
-use App\Lib\Slack;
-use App\Notifications\SlackNotification;
+use Exception, Log;
 
 class Geocoder extends BaseClient
 {
@@ -12,7 +11,7 @@ class Geocoder extends BaseClient
     public function __construct()
     {
         parent::__construct();
-        $base_params = [
+        $this->params = [
             'key' => config('services.google_geocoder.api_key')
         ];
     }
@@ -22,16 +21,16 @@ class Geocoder extends BaseClient
         try {
             $response = $this->get('geocode/json', ['address' => $query]);
         } catch (Exception $e) {
-            ops_error("Exception processing geocoding: {$query}");
-            return false;
-        }
-
-        if ($response->getStatusCode() != 200) {
-            ops_error("Could not process geocoding: {$query} / API Response status code: {$response->getStatusCode()}");
+            ops_error('Geocoder', "Could not process geocoding: {$query} / Exception: {$e->getMessage()}");
             return false;
         }
 
         $obj = json_decode($response->getBody());
+
+        if ($response->getStatusCode() != 200 || empty($obj->results)) {
+            ops_error('Geocoder', "Could not process geocoding: {$query} / Response Code: '{$response->getStatusCode()}' / Message: '{$obj->error_message}'");
+            return false;
+        }
 
         $types = $obj->results[0]->address_components[0]->types ?? [];
 

--- a/config/services.php
+++ b/config/services.php
@@ -93,4 +93,8 @@ return [
         'access_token_file' => env('GCALENDAR_TOKEN_FILE', storage_path('calendar_api/access_token.json')),
         'calendar_id' => env('GCALENDAR_ID', 'goharvey.com_52ld7v7p6tpep95idupudk3b70@group.calendar.google.com'),
     ],
+
+    'google_geocoder' => [
+        'api_key' => env('GOOGLE_GEOCODER_API_KEY'),
+    ],
 ];

--- a/tests/Unit/ZipcodeValidatorTest.php
+++ b/tests/Unit/ZipcodeValidatorTest.php
@@ -20,7 +20,7 @@ class ZipcodeValidatorTest extends TestCase
 
         $state = $zip_code_validator->getState();
 
-        $this->assertEquals($state, "CA");
+        $this->assertEquals('CA', $state);
         $this->assertTrue($zip_code_validator->isServiceable());
     }
 
@@ -31,7 +31,7 @@ class ZipcodeValidatorTest extends TestCase
 
         $state = $zip_code_validator->getState();
 
-        $this->assertEquals($state, "CA");
+        $this->assertEquals('CA', $state);
         $this->assertFalse($zip_code_validator->isServiceable());
     }
 


### PR DESCRIPTION
I found Geocoder is not picking up the Geocoder API key configured on environment variables. Also I'm proposing some improvements on errors handling.
My guess is Geocoding is failing some times on prod due to Google API quota limits.
I found in my local responses like this one _"You have exceeded your daily request quota for this API. We recommend registering for a key at the Google Developers Console: https://console.developers.google.com/apis/credentials?project=_'"_ and since the response code is 200 in this case, error is not noticeable on prod.