### PR TITLE
Remove vendor prefixes from first-party Sass

### DIFF
--- a/resources/assets/scss/base/_forms.scss
+++ b/resources/assets/scss/base/_forms.scss
@@ -251,7 +251,6 @@
   border-radius: 4px;
   border: 1px solid transparent;
   box-shadow: 0 1px 3px 0 #e6ebf1;
-  -webkit-transition: box-shadow 150ms ease;
   transition: box-shadow 150ms ease;
 }
 

--- a/resources/assets/scss/custom/_buttons.scss
+++ b/resources/assets/scss/custom/_buttons.scss
@@ -75,12 +75,6 @@ input[type="submit"] {
     stroke: $gray;
     stroke-width: 6px;
     top: 50%;
-
-    // Don't touch these
-    -ms-transform: translate(-50%,-50%);
-    -webkit-transform: translate(-50%,-50%);
-    -moz-transform: translate(-50%,-50%);
-    -o-transform: translate(-50%,-50%);
     transform: translate(-50%,-50%);
 
     width: 1em;

--- a/resources/assets/scss/modules/_admin.scss
+++ b/resources/assets/scss/modules/_admin.scss
@@ -80,11 +80,6 @@
       left: 15%;
       top: 49%;
       position: absolute;
-
-      -ms-transform: translate(-50%,-50%);
-      -webkit-transform: translate(-50%,-50%);
-      -moz-transform: translate(-50%,-50%);
-      -o-transform: translate(-50%,-50%);
       transform: translate(-50%,-50%);
 
       font-size: 18px;
@@ -112,7 +107,6 @@
     top: 25px;
     left: 49%;
     position: absolute;
-    -webkit-transform: translate(-50%, -50%);
     transform: translate(-50%, -50%);
     transition: border-color .25s ease-in-out;
     width: 100px;

--- a/resources/assets/scss/modules/_modal.scss
+++ b/resources/assets/scss/modules/_modal.scss
@@ -17,13 +17,7 @@
 .modal {
   width: 34em;
   position: fixed;
-
-  // Don't touch these
   top: 40%; left: 50%;
-  -ms-transform: translate(-50%,-40%);
-  -webkit-transform: translate(-50%,-40%);
-  -moz-transform: translate(-50%,-40%);
-  -o-transform: translate(-50%,-40%);
   transform: translate(-50%,-40%);
 
   z-index: 200;
@@ -48,7 +42,7 @@
     @include padding(null null 15px null);
     @include margin(null null 30px null);
   }
-  
+
   .modal-button-container {
     p {
       font-style: italic;

--- a/resources/assets/scss/modules/_signup-practitioner.scss
+++ b/resources/assets/scss/modules/_signup-practitioner.scss
@@ -99,10 +99,6 @@ $practitioner-grid: (
   position: absolute;
   top: 22px;
   left: 50%;
-  -ms-transform: translate(-50%, 0);
-  -webkit-transform: translate(-50%, 0);
-  -moz-transform: translate(-50%, 0);
-  -o-transform: translate(-50%, 0);
   transform: translate(-50%, 0);
 }
 .practitioner-name {

--- a/resources/assets/scss/modules/_signup-quotes.scss
+++ b/resources/assets/scss/modules/_signup-quotes.scss
@@ -43,11 +43,6 @@
   width: 100%;
   height: inherit;
   top: 43%;
-
-  -ms-transform: translate(0,-18%);
-  -webkit-transform: translate(0,-18%);
-  -moz-transform: translate(0,-18%);
-  -o-transform: translate(0,-18%);
   transform: translate(0,-18%);
 
   & > blockquote {

--- a/resources/assets/scss/modules/_user-nav.scss
+++ b/resources/assets/scss/modules/_user-nav.scss
@@ -14,10 +14,6 @@
     left: 15%;
     position: absolute;
     top: 50%;
-    -ms-transform: translate(-50%,-50%);
-    -webkit-transform: translate(-50%,-50%);
-    -moz-transform: translate(-50%,-50%);
-    -o-transform: translate(-50%,-50%);
     transform: translate(-50%,-50%);
   }
 
@@ -78,7 +74,6 @@
   top: 25px;
   left: 49%;
   position: absolute;
-  -webkit-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   transition: border-color 100ms ease-in-out;
   width: 100px;


### PR DESCRIPTION
`autoprefixer` takes care of the need to manually add vendor prefixes.