### PR TITLE
[HAR-1005] adding autoprefixer config

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -19,7 +19,14 @@ mix.options({processCssUrls: false})
    .sass('resources/assets/scss/application.scss', 'public/css')
    .sass('resources/assets/scss/public/app_public.scss', 'public/css')
    .copy('resources/assets/images', 'public/images', false)
-   .sourceMaps();
+   .sourceMaps()
+   .options({
+     postCss: [
+       require('autoprefixer')({
+         browsers: 'last 3 versions',
+       }),
+     ]
+   });
 
 if (mix.inProduction()) {
     mix.version();


### PR DESCRIPTION
adding a bespoke `autoprefixer` config to `webpack.mix.js` to make sure we are targeting the correct browser versions

# Example Output
<img width="898" alt="screen shot 2017-10-17 at 4 50 53 pm" src="https://user-images.githubusercontent.com/420755/31688818-885b0286-b35b-11e7-94b9-ca8af2d24eec.png">
