### PR TITLE
[HAR 1039] enforce PHP spacing rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
+# Indentation for all PHP files
 [*.php]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1039

# Context
JS and Vue.js spacing styles were being enforced with `.editorconfig`, but PHP should also be added.

# Summary of Changes
- Added indentation entry for **all** PHP files in `.editorconfig`

# Front-end Checklist
- [x] Link to Jira ticket included
- n/a Unit tests pass
- n/a Tested in IE, Chrome, Firefox
- n/a Added/updated documentation
