### PR TITLE
[HAR-1040] removing unused stripe-api dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "q": "^1.5.0",
     "sass-loader": "^6.0.3",
     "stripe": "^4.23.2",
-    "stripe-api": "^0.1.2",
     "style-loader": "^0.16.1",
     "vee-validate": "^2.0.0-rc.18",
     "vue": "^2.4.4",


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1040

# Context
It doesn't appear that we are using the `stripe-api` node module. Let's remove it from our dependency list.

# Summary of Changes
- removed `stripe-api` dependency from `package.json`

# Front-end Checklist
- [x] Link to Jira ticket included
- n/a Unit tests pass
- n/a Tested in IE, Chrome, Firefox
- n/a Added/updated documentation
