### PR TITLE
[HAR-1041] Fix for Safari's handling of child overflow content / Modals

### DIFF
--- a/resources/assets/js/pages/lab_orders/components/AddLabOrders.vue
+++ b/resources/assets/js/pages/lab_orders/components/AddLabOrders.vue
@@ -1,5 +1,6 @@
 <template>
   <Flyout
+    :class="$parent.addActiveModal && 'with-active-modal'"
     :active="$parent.addFlyoutActive"
     :heading="flyoutHeading"
     :on-close="handleFlyoutClose"

--- a/resources/assets/scss/modules/_flyout.scss
+++ b/resources/assets/scss/modules/_flyout.scss
@@ -13,6 +13,12 @@
   width: 100%;
   z-index: 9999;
 
+  // for certain situations where sub components outside the dimensions of the flyout
+  // will be hidden
+  &.with-active-modal {
+    overflow-y: visible;
+  }
+
   &__ctas {
     text-align: center;
   }


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1041

# Context
In Safari, any `Modal` attached to a `Flyout` was being hidden due to the Flyout's `overflow-y: scroll` property in conjunction with child elements. `Modal` was outside the dimensions of `Flyout` and was cropped out.

# Summary of Changes
- Adding `bool` class to the flyout so it knows when a modal is active
- active modal flyouts get standard `overflow` settings

# Front-end Checklist
- [x] Link to Jira ticket included
- n/a Unit tests pass
- [x] Tested in IE, Chrome, Firefox, Mobile
- n/a Added/updated documentation

# Screenshots

## Before
<img width="858" alt="screen shot 2017-10-25 at 3 59 28 pm" src="https://user-images.githubusercontent.com/420755/32020615-cb9baa70-b99e-11e7-98ff-1d1de4bdf369.png">


## After
<img width="753" alt="screen shot 2017-10-25 at 4 00 01 pm" src="https://user-images.githubusercontent.com/420755/32020622-cee6e672-b99e-11e7-9e62-44c34f8f3dfa.png">
