### PR TITLE
Har 1064 laborder recommended email

### DIFF
--- a/app/Events/LabOrderRecommended.php
+++ b/app/Events/LabOrderRecommended.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use App\Models\LabOrder;
+
+class LabOrderRecommended
+{
+    use Dispatchable;
+
+    public $lab_order;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(LabOrder $lab_order)
+    {
+        $this->lab_order = $lab_order;
+    }
+}

--- a/app/Listeners/SendPatientLabOrderCreatedEmail.php
+++ b/app/Listeners/SendPatientLabOrderCreatedEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Lib\TransactionalEmail;
+use App\Events\LabOrderRecommended;
+
+class SendPatientLabOrderCreatedEmail implements ShouldQueue
+{
+    public function handle(LabOrderRecommended $event)
+    {
+        $transactionalEmailJob = TransactionalEmail::createJob()
+            ->setTo($event->lab_order->patient->user->email)
+            ->setTemplate('patient.lab_order.recommended')
+            ->setTemplateModel([
+                'sender_name' => $event->lab_order->practitioner->user->full_name,
+                'labs_link' => config('app.url') . '/dashboard#/lab_orders',
+            ]);
+
+        dispatch($transactionalEmailJob);
+    }
+}

--- a/app/Observers/LabOrderObserver.php
+++ b/app/Observers/LabOrderObserver.php
@@ -4,9 +4,24 @@ namespace App\Observers;
 
 use App\Events\{LabOrderConfirmed, LabOrderShipped};
 use App\Models\LabOrder;
+use App\Events\LabOrderRecommended;
 
 class LabOrderObserver
 {
+
+    /**
+     * Listen to the Lab Order created event.
+     *
+     * @param  LabOrder $lab_order
+     * @return void
+     */
+    public function created(LabOrder $lab_order)
+    {
+        if ($lab_order->status_id == LabOrder::RECOMMENDED_STATUS_ID){
+            event(new LabOrderRecommended($lab_order));
+        }
+    }
+
     /**
      * Listen to the LabOrder saved event.
      *

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -49,6 +49,10 @@ class EventServiceProvider extends ServiceProvider
             'App\Listeners\SendPatientLabOrderShippedEmail',
         ],
 
+        'App\Events\LabOrderRecommended' => [
+            'App\Listeners\SendPatientLabOrderCreatedEmail',
+        ],
+
         'App\Events\LabTestProcessing' => [
             'App\Listeners\SendPatientLabTestProcessingEmail',
         ],

--- a/config/services.php
+++ b/config/services.php
@@ -80,6 +80,7 @@ return [
                 'lab_order' => [
                     'confirmed' => 3372143,
                     'shipped' => 2741642,
+                    'recommended' => 3764861,
                 ],
                 'lab_test' => [
                     'processing' => 3148942,

--- a/tests/Feature/TransactionalEmailTest.php
+++ b/tests/Feature/TransactionalEmailTest.php
@@ -232,4 +232,21 @@ class TransactionalEmailTest extends TestCase
 
     }
 
+    public function test_laborder_recommended_notification()
+    {
+        // create a Lab Order
+        $lab_order = factory(LabOrder::class)->create();
+
+        // assert the notification email was sent to the patient
+        $this->assertEmailWasSentTo($lab_order->patient->user->email);
+
+        // assert the information sent was correct
+        $this->assertEmailTemplateNameWas('patient.lab_order.recommended');
+
+        $this->assertEmailTemplateDataWas([
+            'sender_name' => $lab_order->practitioner->user->full_name,
+            'labs_link' => config('app.url') . '/dashboard#/lab_orders',
+        ]);
+    }
+
 }


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1064

# Context
When admin/practitioners creates a new lab-order, we should be sending an email to the client notifying that we have orders the lab-orders and they should login the confirm them.

# Summary of Changes
- Added a new event: LabOrderRecommended
- Added listener for sending email to the client
- Added unit test for the case

# Checklist
- [x] Link to Jira ticket included
- [ ] Tested in IE, Chrome, Firefox
- [ ] Added/Updated Documentation
- [x] Unit Tests pass
- [x] Branch is mergeable
- [x] New methods covered by tests

# Screenshots

## Before

## After
