### PR TITLE
[HAR-945] HOTFIX: New Lab Order Flyout Not Showing in IE11

### DIFF
--- a/resources/assets/js/pages/lab_orders/LabOrders.vue
+++ b/resources/assets/js/pages/lab_orders/LabOrders.vue
@@ -6,7 +6,7 @@
                 <div class="container container-backoffice">
                     <h1 class="heading-1">
                         <span class="text">Lab Orders</span>
-                        <button v-if="!loadingLabs && $root.$data.permissions !== 'patient'" v-on:click="addingFlyoutActive()" class="button main-action circle">
+                        <button v-if="!loadingLabs && $root.$data.permissions !== 'patient'" @click="addingFlyoutActive" class="button main-action circle">
                             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#addition"></use></svg>
                         </button>
                     </h1>
@@ -27,8 +27,7 @@
               :symbol="notificationSymbol"
               :text="notificationMessage"
             />
-            <AddLabOrders v-if="!loadingLabs && $root.$data.permissions != 'patient'"
-            :reset="setupLabData" :labTests="tests" />
+            <AddLabOrders v-if="!loadingLabs && $root.$data.permissions !== 'patient'" :reset="setupLabData" :labTests="tests" />
             <DetailLabOrders v-if="currentData" :row-data="selectedRowData" :reset="setupLabData" />
             <Overlay
                 :active="addFlyoutActive"
@@ -228,14 +227,14 @@
             disabledFilters() {
                 return this.$root.$data.global.loadingLabOrders || this.$root.$data.global.loadingLabTests || this.selectedRowUpdating !== null;
             },
-            filters() { 
+            filters() {
                 return [
-                    {name: `Recommended`, count: this.cache.Recommended.length}, 
-                    {name: `Confirmed`, count: this.cache.Confirmed.length}, 
-                    {name: `Shipped`, count: this.cache.Shipped.length}, 
-                    {name: `Received`, count: this.cache.Received.length}, 
-                    {name: `Mailed`, count: this.cache.Mailed.length}, 
-                    {name: `Processing`, count: this.cache.Processing.length}, 
+                    {name: `Recommended`, count: this.cache.Recommended.length},
+                    {name: `Confirmed`, count: this.cache.Confirmed.length},
+                    {name: `Shipped`, count: this.cache.Shipped.length},
+                    {name: `Received`, count: this.cache.Received.length},
+                    {name: `Mailed`, count: this.cache.Mailed.length},
+                    {name: `Processing`, count: this.cache.Processing.length},
                     {name: `Complete`, count: this.cache.Complete.length}
                 ];
             },

--- a/resources/assets/js/pages/lab_orders/components/AddLabOrders.vue
+++ b/resources/assets/js/pages/lab_orders/components/AddLabOrders.vue
@@ -72,7 +72,7 @@ import axios from 'axios';
 import _ from 'lodash';
 export default {
   props: {
-    reset: Function, 
+    reset: Function,
     labTests: Object
   },
   name: 'AddLabOrders',
@@ -172,7 +172,9 @@ export default {
           this.prevClient = '';
           this.doctorList = [''].concat(this.$root.$data.global.practitioners);
           this.clientList = [''].concat(this.$root.$data.global.patients);
-          Object.values(this.$props.labTests).map(e => e.checked = false);
+
+          Object.keys(this.$props.labTests)
+            .map(test => this.$props.labTests[test].checked = false);
 
           this.$parent.notificationMessage = "Successfully added!";
           this.$parent.notificationActive = true;
@@ -211,17 +213,17 @@ export default {
       if (this.step == 2) return "Enter Tracking #s";
     },
     testNameList() {
-      let prop = this.$props.labTests;
-      let array = Object.values(prop).sort((a,b) => a.id - b.id);
-      return array;
+        return Object.keys(this.$props.labTests)
+            .map(key => this.$props.labTests[key])
+            .sort((a, b) => a.id - b.id);
     }
   },
   watch: {
     testNameList(val) {
       if (val) {
-        let prop = this.$props.labTests;
-        let array = Object.values(prop).sort((a,b) => a.id - b.id);
-        return array;
+          return Object.keys(this.$props.labTests)
+              .map(key => this.$props.labTests[key])
+              .sort((a, b) => a.id - b.id);
       }
     }
   },


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-945

# Context
- Reported that the New Lab Order flyout was not showing on IE11

# Summary of Changes
- The lab test data being passed into `AddLabOrders` was compiled and sorted using `Object.values` which is not a valid method in Internet Explorer (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values)
- Updated those areas to use `Object.keys` instead

# Checklist
- [X] Link to Jira ticket included
- [X] Tested in IE, Chrome, Firefox
- N/A Added/Updated Documentation
- N/A Unit Tests pass
- [X] Branch is mergeable
- N/A New methods covered by tests

# Screenshots
<img width="1258" alt="screen shot 2017-11-13 at 4 20 48 pm" src="https://user-images.githubusercontent.com/13082333/32750484-cbff5cfe-c890-11e7-9826-00c0b2e4ef20.png">

