### PR TITLE
Filter Patient SOAP Notes search results.

### DIFF
--- a/app/Http/Controllers/API/V1/SearchController.php
+++ b/app/Http/Controllers/API/V1/SearchController.php
@@ -1,17 +1,17 @@
 <?php
+
 namespace App\Http\Controllers\API\V1;
 
+use App\Lib\Validation\StrictValidator;
+use App\Models\{Attachment, LabTest, LabTestResult, Prescription, SoapNote};
+use App\Transformers\V1\SearchResultTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
-use App\Transformers\V1\SearchResultTransformer;
-use Exception, ResponseCode, Storage;
-use App\Lib\Validation\StrictValidator;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
-use App\Models\{SoapNote, Attachment, Prescription, LabTestResult, LabTest};
+use Exception, ResponseCode, Storage;
 
 class SearchController extends BaseAPIController
 {
-
     /**
      * LabOrdersController constructor.
      * @param LabOrderTransformer $transformer
@@ -22,7 +22,8 @@ class SearchController extends BaseAPIController
         $this->transformer = $transformer;
     }
 
-    public function search(Request $request){
+    public function search(Request $request)
+    {
         // perform validation
         $validator = StrictValidator::check($request->all(), [
             'term' => 'required|string',
@@ -32,31 +33,32 @@ class SearchController extends BaseAPIController
         $term = request('term');
 
         // search in multiple models
-        $soap_notes = SoapNote::search($term);
+        $soap_notes = SoapNote::whereIn('id', SoapNote::search($term)->get()->pluck('id'));
         $attachments = Attachment::search($term);
         $prescriptions = Prescription::search($term);
-        $labresults = LabTestResult::make();
-        $labresults = $labresults->whereIn('id', LabTestResult::search($term)->get()->pluck('id'));
+        $labresults = LabTestResult::whereIn('id', LabTestResult::search($term)->get()->pluck('id'));
 
         // limit results to current user
-        if (!currentUser()->isAdmin() and currentUser()->isPatient()) {
-            $soap_notes->where('patient_id',currentUser()->patient->id);
-            $soap_notes = $soap_notes->filterForPatient();
-            $attachments->where('patient_id',currentUser()->patient->id);
-            $prescriptions->where('patient_id',currentUser()->patient->id);
-            $labresults->whereIn('lab_test_id',LabTest::whereHas('labOrder',function($query){
-                $query->where('patient_id',currentUser()->patient->id);
-            })->get()->pluck('id'));
-        } elseif (!currentUser()->isAdmin() and currentUser()->isPractitioner()) {
-             $soap_notes->where('created_by_user_id',currentUser()->practitioner->user->id);
-             $attachments->where('created_by_user_id',currentUser()->practitioner->user->id);
-             $prescriptions->where('created_by_user_id',currentUser()->practitioner->user->id);
-             $labresults->whereIn('lab_test_id',LabTest::whereHas('labOrder',function($query){
-                 $query->where('practitioner_id',currentUser()->practitioner->id);
-             })->get()->pluck('id'));
+        if (currentUser()->isNotAdmin()) {
+            if (currentUser()->isPatient()) {
+                $soap_notes->where('patient_id', currentUser()->patient->id)->filterForPatient();
+                $attachments->where('patient_id', currentUser()->patient->id);
+                $prescriptions->where('patient_id', currentUser()->patient->id);
+                $labresults->whereIn('lab_test_id', LabTest::whereHas('labOrder', function ($query) {
+                    $query->where('patient_id', currentUser()->patient->id);
+                })->get()->pluck('id'));
+            } elseif (currentUser()->isPractitioner()) {
+                $soap_notes->where('created_by_user_id', currentUser()->practitioner->user->id);
+                $attachments->where('created_by_user_id', currentUser()->practitioner->user->id);
+                $prescriptions->where('created_by_user_id', currentUser()->practitioner->user->id);
+                $labresults->whereIn('lab_test_id', LabTest::whereHas('labOrder', function ($query) {
+                    $query->where('practitioner_id', currentUser()->practitioner->id);
+                })->get()->pluck('id'));
+            } else {
+                throw new Exception('Unable to filter search results for "' . ucfirst(currentUser()->type) . '" User type.');
+            }
         }
 
-        // build results collection
         $collection = collect($soap_notes->get())
             ->merge(collect($attachments->get()))
             ->merge(collect($prescriptions->get()))
@@ -64,7 +66,7 @@ class SearchController extends BaseAPIController
             ->sortByDesc('created_at');
 
         // add support for pagination
-        if (is_numeric(request('per_page'))){
+        if (is_numeric(request('per_page'))) {
             $perPage = request('per_page');
 
             $currentPage = LengthAwarePaginator::resolveCurrentPage('page');
@@ -84,8 +86,7 @@ class SearchController extends BaseAPIController
                 ]
             );
             $paginator = new IlluminatePaginatorAdapter($paginator);
-        }
-        else{
+        } else {
             $paginator = null;
             $currentPageItems = $collection;
         }

--- a/app/Models/SoapNote.php
+++ b/app/Models/SoapNote.php
@@ -64,6 +64,14 @@ class SoapNote extends Model
 
     public function scopeFilterForPatient(Builder $builder)
     {
-        return $builder->select(['id', 'patient_id', 'created_by_user_id', 'plan']);
+        return $builder->select([
+            'id',
+            'created_at',
+            'created_by_user_id',
+            'deleted_at',
+            'patient_id',
+            'plan',
+            'updated_at',
+        ]);
     }
 }


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1034

# Context
This is where you explain the impetus behind the PR. Why was it necessary?
Query scopes are not supported by Scout, so "filterForPatient()" was failing. Some additional refactor was done to raise an Exception just in case some new user type is added in the future and we don't know how to filter the results. Let's say 'guest' user type is added in the future, with the old implementation, 'guest' is going to be handle the same way as 'admin'. We want to default to "block" instead of "allow".