### PR TITLE
Using 'lodash' isEmpty() to check zip presence.

### DIFF
--- a/resources/assets/js/pages/lab_orders/components/DetailLabOrders.vue
+++ b/resources/assets/js/pages/lab_orders/components/DetailLabOrders.vue
@@ -865,7 +865,6 @@ export default {
         return true;
       }
       return this.zip.split('').filter(e => Number(e) == e).length > 0 && this.zip.length == 5;
-      }
     },
     id() {
       return this.$props.rowData ? this.$props.rowData.id : '';


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1129

# Context
This is where you explain the impetus behind the PR. Why was it necessary?
Handle empty string and null values too when checking zip code key presence.

# Summary of Changes
- Check using isEmtpy instead of "if" conditional.

# Checklist
- [x] Link to Jira ticket included
- [ ] Tested in IE, Chrome, Firefox
- [ ] Added/Updated Documentation
- [x] Unit Tests pass
- [x] Branch is mergeable
- [x] New methods covered by tests