### PR TITLE
HAR-1130 Messages Response Returns Escaped Strings.

### DIFF
--- a/app/Transformers/V1/MessageTransformer.php
+++ b/app/Transformers/V1/MessageTransformer.php
@@ -19,18 +19,18 @@ class MessageTransformer extends TransformerAbstract
     public function transform(Message $message)
     {
         return [
-            'id' => (string) $message->id,
+            'id' => cast_to_string($message->id),
             'created_at' => $message->created_at,
             'is_sender_admin' => (boolean) $message->is_sender_admin,
-            'message' => htmlentities($message->message),
+            'message' => cast_to_string($message->message),
             'read_at' => $message->read_at,
             'recipient_full_name' => $message->recipient->full_name,
             'recipient_image_url' => $message->recipient->image_url,
-            'recipient_user_id' => (string) $message->recipient_user_id,
+            'recipient_user_id' => cast_to_string($message->recipient_user_id),
             'sender_full_name' => $message->sender->full_name,
             'sender_image_url' => $message->sender->image_url,
-            'sender_user_id' => (string) $message->sender_user_id,
-            'subject' => htmlentities($message->subject),
+            'sender_user_id' => cast_to_string($message->sender_user_id),
+            'subject' => cast_to_string($message->subject),
         ];
     }
 


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1130

# Context
This is where you explain the impetus behind the PR. Why was it necessary?
We don't want special characters (like '<' or '&') to be displayed as its html code in the UI.

# Summary of Changes
- Message Transformer.

# Checklist
- [x] Link to Jira ticket included
- [ ] Tested in IE, Chrome, Firefox
- [x] Added/Updated Documentation
- [x] Unit Tests pass
- [x] Branch is mergeable
- [x] New methods covered by tests
