### PR TITLE
[HAR-1157] Temporarily hide Shippo "Generate Label" button

### DIFF
--- a/resources/assets/js/pages/lab_orders/components/DetailLabOrders.vue
+++ b/resources/assets/js/pages/lab_orders/components/DetailLabOrders.vue
@@ -367,9 +367,11 @@
       </div>
 
       <!-- Mark as Shipped -->
+      <!-- HAR-1157 Hiding button until Shippo integration feature is complete
       <div class="button-wrapper">
         <button class="button" @click="confirmShipping">Generate Label</button>
       </div>
+      -->
 
       <div class="button-wrapper">
         <button class="button" @click="markedShipped" :disabled="masterTracking.length == 0">Mark as Shipped</button>


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1157

# Context
Shippo is not quite ready for release so the functionality needs to be hidden temporarily.

# Summary of Changes
- Button markup commented out and annotated

# Checklist
- [x] Link to Jira ticket included
- n/a Tested in IE, Chrome, Firefox
- n/a Added/Updated Documentation
- n/a Unit Tests pass
- [x] Branch is mergeable
- n/a New methods covered by tests

# Screenshots

<img width="342" alt="screen shot 2017-11-29 at 3 52 42 pm" src="https://user-images.githubusercontent.com/420755/33398612-8b7ada70-d51d-11e7-85ee-5be7c5d88748.png">

