### PR TITLE
[HAR-1161] Fix: Re-enter zip link is broken

### DIFF
--- a/resources/assets/js/v2/components/layout/Background.vue
+++ b/resources/assets/js/v2/components/layout/Background.vue
@@ -13,7 +13,7 @@ export default {
   },
   computed: {
       style() {
-          return `bg is-${this.color}`;
+          return `bg is-${this.color || 'slate'}`;
       }
   }
 };

--- a/resources/assets/js/v2/components/pages/conditions/children/VerifyZip.vue
+++ b/resources/assets/js/v2/components/pages/conditions/children/VerifyZip.vue
@@ -36,15 +36,10 @@
             We will let you know as soon as we launch in your state. In the meantime, you can follow on us social media for free health tips from our team of Naturopathic Doctors.
         </Paragraph>
         <Spacer isBottom :size="4" />
-        <a href="#" @click="reEnterZip">
+        <a href="#" @click="reEnterZip" class="dark-gray">
           <i class="fa fa-undo"></i><Spacer isRight :size="3" />Try Again
         </a>
         <Spacer isBottom :size="4" />
-        <div>
-          <a class="social-icon f2" v-for="icon in Config.misc.socialMedia" :href="icon.href" target="_blank">
-            <i :class="icon.class"></i>
-          </a>
-        </div>
       </SlideIn>
     </div>
   </div>

--- a/resources/views/pages/conditions.blade.php
+++ b/resources/views/pages/conditions.blade.php
@@ -54,9 +54,11 @@
         <script>
             App.setState('conditions.all', {!! $conditions !!});
             App.setState('conditions.labTests', {!! $lab_tests !!});
-            @foreach ($lab_tests as $test)
-                App.setState('conditions.labTests.{!! $loop->index !!}.sku', {!! $test->sku !!});
-            @endforeach
+            @isset($lab_tests)
+                @foreach ($lab_tests as $test)
+                    App.setState('conditions.labTests.{!! $loop->index !!}.sku', {!! $test->sku !!});
+                @endforeach
+            @endisset
             @if ($get_zip) {
                 App.setState('conditions.condition', {questions: []});
                 App.setState('conditions.questionIndex', 999);


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1161

# Context
- The re-enter zip link results in a blade template error

# Summary of Changes
- Check if `$lab_tests` is set before looping over it in blade template
- Make default background fade color `slate` for `/conditions/get-zip`
- Update link color on out-of-range interstitial and remove social icons since they exist in the footer

# Checklist
- [X] Link to Jira ticket included
- [X] Tested in IE, Chrome, Firefox
- [ ] Added/Updated Documentation
- [X] Unit Tests pass
- [X] Branch is mergeable
- [ ] New methods covered by tests
