### PR TITLE
Har 1189 recent messages

### DIFF
--- a/app/Http/Controllers/API/V1/MessagesController.php
+++ b/app/Http/Controllers/API/V1/MessagesController.php
@@ -62,15 +62,10 @@ class MessagesController extends BaseAPIController
         // filter by most recent messages
 
         // get the date if the first unread message
-        $query = clone $builder;
-        $unread_date = $query->orderBy('created_at', 'asc')->unread()->limit(1)->value('created_at');
-        $date_from = (!empty($unread_date))? \Carbon::parse($unread_date):null;
-
+        $date_from = (clone $builder)->orderBy('created_at')->unread()->value('created_at');
         if(empty($date_from)){
-            // get the date of the latest message
-            $query = clone $builder;
-            $latest_date = $query->orderBy('created_at', 'desc')->limit(1)->value('created_at');
-            $date_from = (!empty($latest_date))? \Carbon::parse($latest_date):null;
+            // get the date of the latest message            
+            $date_from = (clone $builder)->orderBy('created_at', 'desc')->value('created_at');
         }
 
         if (!empty($date_from)){

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -335,14 +335,17 @@ class MessageTest extends TestCase
         // creates some old Messages
         factory(Message::class)->create([
             'recipient_user_id' => $patient->user->id,
-            'created_at' => \Carbon::parse('-20 days')
+            'read_at'=> \Carbon::parse('-21 days'),
+            'created_at' => \Carbon::parse('-21 days')
         ]);
         factory(Message::class)->create([
             'recipient_user_id' => $patient->user->id,
+            'read_at'=> \Carbon::parse('-15 days'),
             'created_at' => \Carbon::parse('-15 days')
         ]);
         factory(Message::class)->create([
             'sender_user_id' => $patient->user->id,
+            'read_at'=> \Carbon::parse('-10 days'),
             'created_at' => \Carbon::parse('-10 days')
         ]);
 


### PR DESCRIPTION
**Jira Ticket:**https://homehero.atlassian.net/browse/HAR-1189

# Context
When there are much messages in the inbox, users are spending much time scrolling to find relevant messages. 
We decided only to show the most recent messages (10 days ago from the last message or unread message)

# Summary of Changes
- Added filter on the GET API endpoint
- Added Test Cases

# Checklist
- [x] Link to Jira ticket included
- [ ] Tested in IE, Chrome, Firefox
- [ ] Added/Updated Documentation
- [x] Unit Tests pass
- [x] Branch is mergeable
- [x] New methods covered by tests

# Screenshots

## Before

## After
