### PR TITLE
[HAR-1182] Remove Discovery Quiz

### DIFF
--- a/resources/assets/js/v2/components/pages/conditions/Conditions.vue
+++ b/resources/assets/js/v2/components/pages/conditions/Conditions.vue
@@ -4,7 +4,6 @@
         <PublicNav forceDark giveSpace hasLogo hasLinks hasPhone isSticky />
         <div class="center mw9 pa3 pa4-m">
             <ConditionPreface v-if="!State('conditions.prefaceRead')" />
-            <ConditionQuestions v-else-if="State('conditions.questionIndex') < State('conditions.condition.questions').length" />
             <VerifyZip v-else-if="!State('conditions.zipValidation') || State('conditions.zipValidation.is_serviceable') === false" />
         </div>
         <MainSubFooter />

--- a/resources/assets/js/v2/components/pages/conditions/children/ConditionPreface.vue
+++ b/resources/assets/js/v2/components/pages/conditions/children/ConditionPreface.vue
@@ -57,7 +57,7 @@
 
     <!-- Quiz -->
     <div class="tc w-100 w-80-ns w-50-l margin-0a pv5 ph4">
-      <Heading2>Take our {{ State('conditions.condition.name') }} quiz to determine if Harvey Health is right for you.</Heading2>
+      <Heading2>Sign up and see if Harvey Health is right for you.</Heading2>
       <InputButton
         :text="button"
         :type="'whiteFilled'"


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1182

# Context
- In order to test conversion metrics from homepage to signup, we're going to remove the discovery quiz and go right to the zip-code entry when the user clicks 'Get Started' button on the conditions page

# Summary of Changes
- Remove discovery quiz and skip right to zip-code entry
- Update copy in footer 'Get Started' CTA section

# Checklist
- [X] Link to Jira ticket included
- [X] Tested in IE, Chrome, Firefox
- [ ] Added/Updated Documentation
- [X] Unit Tests pass
- [X] Branch is mergeable
- [ ] New methods covered by tests
