### PR TITLE
[HAR-1171] Simplify Zip Input on Zip Code Page

### DIFF
--- a/resources/assets/js/v2/components/inputs/CodeInput.vue
+++ b/resources/assets/js/v2/components/inputs/CodeInput.vue
@@ -1,6 +1,6 @@
 <template>
     <TheMask
-        class="code-input"
+        :class="classes"
         :disabled="isDisabled"
         :mask="mask"
         :placeholder="mask.split('').map(a => '●').join('')"
@@ -23,6 +23,15 @@ export default {
             type: String,
             required: true
         },
+        theme: {
+            type: String,
+            default: 'primary',
+            validator(theme) {
+                const validThemes = ['primary', 'inverse-dark'];
+
+                return validThemes.indexOf(theme) > -1;
+            }
+        },
         type: {
             type: String,
             default: 'text'
@@ -42,6 +51,15 @@ export default {
         TheMask
     },
 
+    computed: {
+        classes() {
+            return {
+                'code-input': true,
+                [`${this.theme}`]: true
+            }
+        }
+    },
+
     methods: {
         handleInput(v) {
             this.onInput(v);
@@ -50,7 +68,6 @@ export default {
 
     mounted() {
         if (this.isAutoFocused) {
-            console.log(this.$refs.code_input_ref);
             this.$refs.code_input_ref.$el.focus();
         }
     }
@@ -63,12 +80,21 @@ export default {
     .code-input {
         @extend %input--text-reset;
 
-        background: $color-gray-5;
         border-radius: 6px;
         font-size: 28px;
         font-weight: 600;
         letter-spacing: 6px;
         padding: 6px 10px;
         text-align: center;
+
+        // Input modes
+        &.primary {
+            background: $color-gray-5;
+        }
+
+        &.inverse-dark {
+            background: transparent;
+            border: 3px solid $color-copy;
+        }
     }
 </style>

--- a/resources/assets/js/v2/components/pages/conditions/children/VerifyZip.vue
+++ b/resources/assets/js/v2/components/pages/conditions/children/VerifyZip.vue
@@ -13,6 +13,7 @@
                     :isDisabled="State('isLoading.zip') || (State('wasRequested.zip') && !State('isLoading.zip'))"
                     :mask="'#####'"
                     :onInput="zip => setState('conditions.zip', zip)"
+                    :theme="'inverse-dark'"
                 />
                 <Spacer isBottom :size="4" />
                 <InputButton


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1171

# Context
- The `MultiInput` component is not very user-friendly on mobile and `VerifyZip` needs it replaced with something simpler.

# Summary of Changes
- Replaced `MultiInput` with `CodeInput`
- Updated `CodeInput` to take a theme for different contexts

# Checklist
- [X] Link to Jira ticket included
- [X] Tested in IE, Chrome, Firefox
- [X] Added/Updated Documentation
- [X] Unit Tests pass
- [X] Branch is mergeable
- [ ] New methods covered by tests

# Screenshots
<img width="767" alt="screen shot 2017-12-13 at 10 46 51 am" src="https://user-images.githubusercontent.com/13082333/33947713-252cc98c-dff3-11e7-9d4a-d8357228f681.png">
