### PR TITLE
HAR-1265 Appointments | Time slots are not removed.

### DIFF
--- a/app/Lib/PractitionerAvailability.php
+++ b/app/Lib/PractitionerAvailability.php
@@ -225,7 +225,7 @@ class PractitionerAvailability
         $date = clone $week;
         $date->tz = $practitioner_timezone;
 
-        $week_of_year = $date->weekOfYear;
+        $week_of_year = sprintf('%02d', $date->weekOfYear);
         $year = $date->year;
 
         $start_date = Carbon::createFromTimestamp(strtotime("{$year}W{$week_of_year}"));


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1265

# Context
This is where you explain the impetus behind the PR. Why was it necessary?
Appointments overlapping was reported by Practitioners.
The issue was on strtotime() argument. '2017W52' and '2018W01' are valid, but '2018W1' is not. Two digits are expected after 'W'.

# Summary of Changes
- This is something that was changed
- This is another thing that was changed

# Checklist
- [x] Link to Jira ticket included
- [x] Tested in IE, Chrome, Firefox
- [x] Added/Updated Documentation
- [x] Unit Tests pass
- [x] Branch is mergeable
- [x] New methods covered by tests
