### PR TITLE
Fix blog subdomain redirect

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,9 @@ use Illuminate\Routing\Controller;
 
 // stupid blog re-routing
 Route::domain('blog.goharvey.com')->group(function () {
-    Route::redirect('/', '/blog', 301);
+    Route::get('/', function() {
+        return redirect('/blog', 301);
+    });
 });
 
 // AUTHENTICATION


### PR DESCRIPTION
Since there is no redirect attribute in the Route facade, this was breaking artisan commands.