### PR TITLE
[HAR-1319] Back Button Fix on Zipcode Page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -78,7 +78,7 @@
 
             <footer class="card-footer">
                 <div class="card-footer-item level">
-                    <a href="/get-started" class="button login-buttons">Sign Up</a>
+                    <a href="/get-started#/signup" class="button login-buttons">Sign Up</a>
                     <button type="submit" class="button is-primary login-buttons">
                       <span v-if="!isProcessing">Log In</span>
                       <loading-graphic v-else :size="12" />

--- a/resources/views/legacy/pages/consultations.blade.php
+++ b/resources/views/legacy/pages/consultations.blade.php
@@ -15,7 +15,7 @@
                 <h1 class="f1-l f2 lh-title mt0 mb3 ph3 white">Book a consultation with <br class="dn db-ns"/>a Naturopathic Doctor.</h1>
                 <p class="f4-l f5 fw5 mb4 ph3 white">Schedule a 1-hour consultation with a licensed Naturopathic Doctor <br class="dn db-ns"/>to review lab results or build a personalized treatment plan.</p>
                 <div class="tc">
-                    <a href="/get-started" class="button f4-l f5 ph4 is-primary has-arrow">Check Availability</a>
+                    <a href="/get-started#/signup" class="button f4-l f5 ph4 is-primary has-arrow">Check Availability</a>
                     <p class="f5-l f6 fw5 db cf ma3 white">Questions? <a href="https://telegram.me/goharvey_doctors" class="underline white dim" target="_blank">Chat free with a doctor</a></p>
                 </div>
             </div>
@@ -234,7 +234,7 @@
                 <p class="f2-l f3">Serving patients across 40 states.</p>
                 <p class="f4-l f5 pa3">We recommend talking with a doctor to receive a full treatment plan. You can book a video consultation today or start a private chat with one of our doctors on Telegram.</p>
                 <div class="tc">
-                    <a href="/get-started" class="button f4-ns f5 ph4 is-primary has-arrow">Check Availability</a>
+                    <a href="/get-started#/signup" class="button f4-ns f5 ph4 is-primary has-arrow">Check Availability</a>
                     <p class="f5-l f6 fw5 db cf ma3">Questions? <a href="https://telegram.me/goharvey_doctors" class="underline dim" target="_blank">Chat free with a doctor</a></p>
                 </div>
             </div>

--- a/resources/views/legacy/pages/lab_tests.blade.php
+++ b/resources/views/legacy/pages/lab_tests.blade.php
@@ -125,16 +125,4 @@
     </div>
 </section>
 
-<!-- <section class="section get-started">
-    <div class="container">
-        <div class="has-text-centered has-max-width-lg">
-            <h2 class="title is-3">Convenient, accurate lab testing.</h2>
-            <p class="copy-has-max-width subtitle is-4-desktop is-5-mobile is-padding-top">If you would like to take one of our specialized in-home lab tests, please tell us the condition you would like help treating.</p>
-            <div class="button-wrapper">
-                <a href="/#conditions" class="button is-primary is-medium has-arrow">Explore Conditions</a>
-            </div>
-        </div>
-    </div>
-</section> -->
-
 @endsection

--- a/resources/views/pages/dashboard/index.blade.php
+++ b/resources/views/pages/dashboard/index.blade.php
@@ -14,7 +14,7 @@
     if ( Laravel.user.signedIn &&
         !Laravel.user.has_an_appointment &&
         Laravel.user.user_type === 'patient' ) {
-        window.location.href = '/get-started';
+        window.location.href = '/get-started#/signup';
     } else {
       window.$$context = 'dashboard';
     }


### PR DESCRIPTION
**Jira Ticket:** https://homehero.atlassian.net/browse/HAR-1319

# Context
- If user clicks back button on zip page they get a blank screen
- All links to `/get-started` were loading the initial `GetStarted` component and then pushing to `#/signup` if necessary. Since the hash was registered as a navigation action, going back just sent them to the initial component after it had mounted

# Summary of Changes
- Changed all `/get-started` links to `/get-started#/signup` so the back button redirects to the previous page

# Checklist
- [X] Link to Jira ticket included
- [N/A] Tested in IE, Chrome, Firefox
- [N/A] Added/Updated Documentation
- [X] Unit Tests pass
- [X] Branch is mergeable
- [N/A] New methods covered by tests
